### PR TITLE
The patch to OpenCV was impacted by the change to CMAKE_INSTALL_LIBDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ if (fletch_BUILD_WITH_PYTHON)
       unset(PYTHON_LIBRARY_DEBUG CACHE)
     endif()
   endif()
-  
+
   # Choose python 2 or python 3
   if (fletch_PYTHON_MAJOR_VERSION MATCHES "^3.*")
       set(fletch_python2 False)

--- a/Patches/OpenCV/3.4.0/apps/annotation/CMakeLists.txt
+++ b/Patches/OpenCV/3.4.0/apps/annotation/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 project(annotation)
 set(the_target opencv_annotation)
 
-link_directories(${OPENCV_LIB_INSTALL_PATH})
+link_directories(${CMAKE_INSTALL_PREFIX}/${OPENCV_LIB_INSTALL_PATH})
 
 ocv_target_include_directories(${the_target} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}" "${OpenCV_SOURCE_DIR}/include/opencv")
 ocv_target_include_modules_recurse(${the_target} ${OPENCV_ANNOTATION_DEPS})

--- a/Patches/OpenCV/3.4.0/apps/createsamples/CMakeLists.txt
+++ b/Patches/OpenCV/3.4.0/apps/createsamples/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 project(createsamples)
 set(the_target opencv_createsamples)
 
-link_directories(${OPENCV_LIB_INSTALL_PATH})
+link_directories(${CMAKE_INSTALL_PREFIX}/${OPENCV_LIB_INSTALL_PATH})
 
 ocv_target_include_directories(${the_target} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}" "${OpenCV_SOURCE_DIR}/include/opencv")
 ocv_target_include_modules_recurse(${the_target} ${OPENCV_CREATESAMPLES_DEPS})

--- a/Patches/OpenCV/3.4.0/apps/interactive-calibration/CMakeLists.txt
+++ b/Patches/OpenCV/3.4.0/apps/interactive-calibration/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 project(interactive-calibration)
 set(the_target opencv_interactive-calibration)
 
-link_directories(${OPENCV_LIB_INSTALL_PATH})
+link_directories(${CMAKE_INSTALL_PREFIX}/${OPENCV_LIB_INSTALL_PATH})
 
 ocv_target_include_directories(${the_target} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}" "${OpenCV_SOURCE_DIR}/include/opencv")
 ocv_target_include_modules_recurse(${the_target} ${OPENCV_INTERACTIVECALIBRATION_DEPS})

--- a/Patches/OpenCV/3.4.0/apps/traincascade/CMakeLists.txt
+++ b/Patches/OpenCV/3.4.0/apps/traincascade/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 project(traincascade)
 set(the_target opencv_traincascade)
 
-link_directories(${OPENCV_LIB_INSTALL_PATH})
+link_directories(${CMAKE_INSTALL_PREFIX}/${OPENCV_LIB_INSTALL_PATH})
 
 ocv_warnings_disable(CMAKE_CXX_FLAGS -Woverloaded-virtual)
 

--- a/Patches/OpenCV/3.4.0/apps/version/CMakeLists.txt
+++ b/Patches/OpenCV/3.4.0/apps/version/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 project(opencv_version)
 set(the_target opencv_version)
 
-link_directories(${OPENCV_LIB_INSTALL_PATH})
+link_directories(${CMAKE_INSTALL_PREFIX}/${OPENCV_LIB_INSTALL_PATH})
 
 ocv_target_include_directories(${the_target} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}" "${OpenCV_SOURCE_DIR}/include/opencv")
 ocv_target_include_modules_recurse(${the_target} ${OPENCV_APPLICATION_DEPS})

--- a/Patches/OpenCV/3.4.0/apps/visualisation/CMakeLists.txt
+++ b/Patches/OpenCV/3.4.0/apps/visualisation/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 project(visualisation)
 set(the_target opencv_visualisation)
 
-link_directories(${OPENCV_LIB_INSTALL_PATH})
+link_directories(${CMAKE_INSTALL_PREFIX}/${OPENCV_LIB_INSTALL_PATH})
 
 ocv_target_include_directories(${the_target} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}" "${OpenCV_SOURCE_DIR}/include/opencv")
 ocv_target_include_modules_recurse(${the_target} ${OPENCV_VISUALISATION_DEPS})


### PR DESCRIPTION
This fix to the OpenCV patch is required to keep version 3.4.0 building correctly.